### PR TITLE
Fix problems decrypting with the -f option

### DIFF
--- a/src/jass
+++ b/src/jass
@@ -160,9 +160,6 @@ decrypt() {
 	verbose "Decrypting session key..." 2
 	openssl rsautl -inkey "${KEYFILE}" -decrypt -in "${KEYDIR}/${skey}" -out "${TDIR}/skey"
 
-	if [ x"${FILE}" != x"/dev/stdin" ]; then
-		output="${outfile}"
-	fi
 	verbose "Decrypting message using session key..." 2
 	openssl enc -d -aes-256-cbc -pass "file:${TDIR}/skey"	\
 		-in "${msgdir}/${outfile}" -out "${output}"


### PR DESCRIPTION
If you attempt to decrypt a relative filename with the -f option, this happens:

  $ jass -df passwords
  awk: cannot open passwords (No such file or directory)

Also, if you specify any input file to decrypt with the -f option, files are written to a plaintext file called message.

These commits fix that for me.
