### PR TITLE
Fix for missing directories and wrong filename in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ dmg: osx/jass.dmg
 osx/${NAME}.dmg: build
 	cp -R osx/${NAME}.pkg osx/${NAME}-${VERSION}.pkg
 	hdiutil create -volname Jass -srcfolder osx/${NAME}-${VERSION}.pkg -ov -format UDZO osx/${NAME}-${VERSION}.dmg
+	mkdir -p packages/dmgs
 	cp osx/${NAME}-${VERSION}.dmg packages/dmgs/
 
 osx/${NAME}-${VERSION}.dmg: osx/${NAME}.dmg
@@ -84,7 +85,7 @@ prep: .prepdone
 	install -c -m 0755 src/${NAME} ${DSTROOT}${PREFIX}/bin/${NAME}
 	install -c -m 0644 doc/${NAME}.1 ${DSTROOT}${PREFIX}/share/man/man1/${NAME}.1
 	mkdir -p osx/${NAME}.pkg/Contents/Resources
-	install -c -m 644 README osx/${NAME}.pkg/Contents/Resources/ReadMe.txt
+	install -c -m 644 README.md osx/${NAME}.pkg/Contents/Resources/ReadMe.txt
 	install -c -m 644 LICENSE osx/${NAME}.pkg/Contents/Resources/License.txt
 	sudo chown -R root:staff ${DSTROOT}
 	touch .prepdone


### PR DESCRIPTION
The packages/dmgs doesn't exist for make osxpkg to complete and the Readme file is README.md in the repo.