### PR TITLE
Regex change to handle hyphens in file names.

### DIFF
--- a/src/jass.go
+++ b/src/jass.go
@@ -795,7 +795,7 @@ func identifyCorrectSessionKeyData(privfp string, keys map[string]string) (skey 
 	verbose("Identifying correct session key data...", 2)
 
 	/* fingerprints may be "user-fi:ng:er:pr:in:t" or "fi:ng:er:pr:in:t" */
-	fp_pattern := regexp.MustCompile("^([^-]+-)?(?P<fp>[a-f0-9:]+)")
+	fp_pattern := regexp.MustCompile("^(.+-)?(?P<fp>[[:xdigit:]:]+)$")
 
 	for r, key := range keys {
 		fp := fp_pattern.FindStringSubmatch(r)[2]


### PR DESCRIPTION
For https://github.com/jschauma/jass/issues/11

```
package main

import "regexp"
import "fmt"

func main() {

  fp_pattern := regexp.MustCompile("^([^-]+-)?(?P<fp>[a-f0-9:]+)")
  fp_pattern2 := regexp.MustCompile("^(.+-)?(?P<fp>[[:xdigit:]:]+)$")

  strings := []string{}
  strings = append(strings, "ssh-keys/seph/id_rsa.pub-49:84:63:1e:ce:c7:87:99:4d:0f:fb:66:1c:6f:30:da")
  strings = append(strings, "sshkeys/seph/id_rsa.pub-49:84:63:1e:ce:c7:87:99:4d:0f:fb:66:1c:6f:30:da")
  strings = append(strings, "49:84:63:1e:ce:c7:87:99:4d:0f:fb:66:1c:6f:30:da")

  for i := range strings {
    string := strings[i]
    fmt.Println(string)
    fmt.Println(fp_pattern.FindStringSubmatch(string))
    fmt.Println(fp_pattern2.FindStringSubmatch(string))
  }
}
```